### PR TITLE
Implement `Generate report` 

### DIFF
--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -559,6 +559,7 @@ class ReportDialog(Gtk.Window):
 
         vboxrv = Gtk.VBox()
         vboxmv = Gtk.VBox()
+        vboxev = Gtk.VBox()
 
         # Report View
 
@@ -616,9 +617,36 @@ class ReportDialog(Gtk.Window):
         hboxmv.pack_start(self.close_btn, True, True, 4)
 
         vboxmv.pack_start(hboxmv, True, True, 4)
+
+        # Error view
+
+        vboxev.set_margin_start(20)
+        vboxev.set_margin_end(20)
+        vboxev.set_margin_top(10)
+        vboxev.set_margin_bottom(10)
+
+        hboxev = Gtk.HBox()
+        hboxev.set_margin_start(5)
+        hboxev.set_margin_end(5)
+
+        self.err_code = ""
+
+        self.err_code_label = Gtk.Label.new(self.err_code)
+
+        vboxev.pack_start(self.err_code_label, True, True, 4)
+
+        self.close_btn_err = Gtk.Button.new_with_label(_('Close'))
+        self.close_btn_err.connect("clicked", self.on_close_button)
+
+        hboxev.pack_start(self.close_btn_err, True, True, 4)
+
+        vboxev.pack_start(hboxev, True, True, 4)
+
         self.stack.add_named(vboxrv, name = "Report view")
 
         self.stack.add_named(vboxmv, name = "Message view")
+
+        self.stack.add_named(vboxev, name = "Error view")
 
         self.add(self.stack)
 
@@ -633,7 +661,13 @@ class ReportDialog(Gtk.Window):
             self.progress_bar.pulse()
         
         if args[1] != "":
-            self.path = args[1]
+            self.err_code_label.set_label("Error! Report wasn't able to be generated\nError : " + self.err_code)
+            self.stack.set_visible_child_name("Error view")
+            self.err_code = args[1]
+
+        if args[2] != "":
+            self.path = args[2]
+
 
     def on_report_button_common(self, widget, str):
         self.bar_thread = ReportThread(self.prog_bar_proc, str)

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -408,6 +408,11 @@ class ServiceIndicator(Gio.Application):
         menu.append(separator)
         menu.append(about_item)
 
+        self.report = Gtk.MenuItem.new_with_label(_('Gen Report'))
+        self.report.connect('activate', self.on_report_item)
+        self.report.show()
+        menu.append(self.report)
+
         bug_item = Gtk.MenuItem(label=_(
             'Report a bug...'))
         bug_item.connect(
@@ -500,6 +505,10 @@ this program. If not, see <http://www.gnu.org/licenses/>.
             self.about_dialog.destroy()
             self.about_dialog = None
 
+    def on_report_item(self, widget, data=None):
+        self.show_report()
+
+
     # Interface and Method
 
     def on_news_delete_event(self, window, event):
@@ -518,7 +527,51 @@ this program. If not, see <http://www.gnu.org/licenses/>.
         self.menu_preferences.set_sensitive(False)
         preferences_dialog = PreferencesDialog()
         preferences_dialog.connect("preferences-close",self.on_preferences_close)
-        
+
+    def show_report(self):
+        self.report.set_sensitive(False)
+        report_dialog = ReportDialog()
+
+class ReportDialog(Gtk.Window):
+    def __init__(self):
+        Gtk.Window.__init__(self)
+        self.set_modal(True)
+                
+        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        self.set_icon(GdkPixbuf.Pixbuf.new_from_file_at_scale(
+            common.ICON, 64, 64, True))
+
+        header = Gtk.HeaderBar()
+        header.set_title(_('Generating Report'))
+        header.set_show_close_button(True)
+
+        self.set_titlebar(header)
+
+        vbox = Gtk.VBox(spacing = 20)
+
+        self.progress_bar = Gtk.ProgressBar()
+
+        vbox.pack_start(self.progress_bar, True, True, 40)
+
+        self.add(vbox)
+
+        self.bar_thread = ReportThread(self.prog_bar_proc)
+        self.bar_thread.start()
+
+        self.show_all()
+
+    def prog_bar_proc(self):
+        self.progress_bar.pulse()
+
+class ReportThread(threading.Thread):
+    def __init__(self, cb):
+        threading.Thread.__init__(self)
+        self.callback = cb
+
+    def run(self):
+        GLib.idle_add(self.callback)    
+
+
 class PreferencesDialog(Gtk.Window):
     def __init__(self):
         Gtk.Window.__init__(self)

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -548,7 +548,7 @@ class ReportDialog(Gtk.Window):
             common.ICON, 64, 64, True))
 
         header = Gtk.HeaderBar()
-        header.set_title(_('Generating Report'))
+        header.set_title(_('Generate Report'))
         header.set_show_close_button(True)
 
         self.set_titlebar(header)

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -517,7 +517,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
         self.menu_news.set_sensitive(True)
         self.indicator.set_status(appindicator.IndicatorStatus.ACTIVE) if self.show else self.indicator.set_status(
             appindicator.IndicatorStatus.PASSIVE)
-    
+
     def on_preferences_close(self, *args):
         self.menu_preferences.set_sensitive(True)
         self.read_preferences()
@@ -533,11 +533,14 @@ this program. If not, see <http://www.gnu.org/licenses/>.
     def show_report(self):
         self.report.set_sensitive(False)
         report_dialog = ReportDialog()
+        self.report.set_sensitive(True)
 
 class ReportDialog(Gtk.Window):
     def __init__(self):
         Gtk.Window.__init__(self)
         self.set_modal(True)
+
+        self.connect('delete-event',self.on_report_delete_event)
                 
         self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
         self.set_icon(GdkPixbuf.Pixbuf.new_from_file_at_scale(
@@ -574,6 +577,10 @@ class ReportDialog(Gtk.Window):
         if args[1] != "":
             self.progress_bar.set_text("Report dumped at " + args[1])
 
+    def on_report_delete_event(self, window, event):
+        self.set_sensitive(False)
+
+
 class ReportThread(threading.Thread):
     def __init__(self, cb):
         threading.Thread.__init__(self)
@@ -581,7 +588,6 @@ class ReportThread(threading.Thread):
 
     def run(self):
         common.report_proc(self, GLib.idle_add, self.callback)
-
 
 
 class PreferencesDialog(Gtk.Window):

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -557,6 +557,7 @@ class ReportDialog(Gtk.Window):
         vbox.set_margin_end(20)
 
         self.progress_bar = Gtk.ProgressBar()
+        self.progress_bar.set_text("")
         self.progress_bar.set_show_text(True)
 
         vbox.pack_start(self.progress_bar, True, True, 40)

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -538,6 +538,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 class ReportDialog(Gtk.Window):
     def __init__(self):
         Gtk.Window.__init__(self)
+        self.set_default_size(400, 100)
         self.set_modal(True)
 
         self.connect('delete-event',self.on_report_delete_event)
@@ -556,16 +557,29 @@ class ReportDialog(Gtk.Window):
         vbox.set_margin_start(20)
         vbox.set_margin_end(20)
 
+        hbox = Gtk.HBox()
+        hbox.set_margin_start(5)
+        hbox.set_margin_end(5)
+
+        self.normal_report_btn = Gtk.Button.new_with_label(_("Report"))
+        self.normal_report_btn.connect("clicked",self.on_report_button)
+
+        self.full_report_btn = Gtk.Button.new_with_label(_("Full Report"))
+        self.full_report_btn.connect("clicked",self.on_full_report_button)
+
+        hbox.pack_start(self.normal_report_btn, True, True, 4)
+        hbox.pack_start(self.full_report_btn, True, True, 4)
+        
+
+        vbox.pack_start(hbox, True, True, 4)
+
         self.progress_bar = Gtk.ProgressBar()
         self.progress_bar.set_text("")
         self.progress_bar.set_show_text(True)
 
-        vbox.pack_start(self.progress_bar, True, True, 40)
+        vbox.pack_start(self.progress_bar, True, True, 4)
 
         self.add(vbox)
-
-        self.bar_thread = ReportThread(self.prog_bar_proc)
-        self.bar_thread.start()
 
         self.show_all()
 
@@ -578,17 +592,31 @@ class ReportDialog(Gtk.Window):
         if args[1] != "":
             self.progress_bar.set_text("Report dumped at " + args[1])
 
+    def on_report_button(self, widget):
+        self.bar_thread = ReportThread(self.prog_bar_proc, "report")
+        self.bar_thread.start()
+        self.disable_buttons()
+
+    def on_full_report_button(self, widget):
+        self.bar_thread = ReportThread(self.prog_bar_proc, "report-full")
+        self.bar_thread.start()
+        self.disable_buttons()
+
+    def disable_buttons(self):
+        self.normal_report_btn.set_sensitive(False)
+        self.full_report_btn.set_sensitive(False)  
+
     def on_report_delete_event(self, window, event):
         self.set_sensitive(False)
 
-
 class ReportThread(threading.Thread):
-    def __init__(self, cb):
+    def __init__(self, cb, report_type):
         threading.Thread.__init__(self)
         self.callback = cb
+        self.report_type = report_type
 
     def run(self):
-        common.report_proc(self, GLib.idle_add, self.callback)
+        common.report_proc(self, GLib.idle_add, self.callback, self.report_type)
 
 
 class PreferencesDialog(Gtk.Window):

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -410,7 +410,7 @@ class ServiceIndicator(Gio.Application):
         menu.append(separator)
         menu.append(about_item)
 
-        self.report = Gtk.MenuItem.new_with_label(_('Generate Report'))
+        self.report = Gtk.MenuItem.new_with_label(_('Generate report'))
         self.report.connect('activate', self.on_report_item)
         self.report.show()
         menu.append(self.report)
@@ -548,7 +548,7 @@ class ReportDialog(Gtk.Window):
             common.ICON, 64, 64, True))
 
         header = Gtk.HeaderBar()
-        header.set_title(_('Generate Report'))
+        header.set_title(_('Generate report'))
         header.set_show_close_button(True)
 
         self.set_titlebar(header)
@@ -556,21 +556,26 @@ class ReportDialog(Gtk.Window):
         vbox = Gtk.VBox()
         vbox.set_margin_start(20)
         vbox.set_margin_end(20)
+        vbox.set_margin_top(10)
+        vbox.set_margin_bottom(10)
 
         hbox = Gtk.HBox()
         hbox.set_margin_start(5)
         hbox.set_margin_end(5)
 
+        report_desc = Gtk.Label.new("This is a report of several hardware and software stats.\nFull report generates a report with sensitive information,\nbeware of sharing it online!")
+
+        vbox.pack_start(report_desc, True, True, 4)
+
         self.normal_report_btn = Gtk.Button.new_with_label(_("Report"))
         self.normal_report_btn.connect("clicked",self.on_report_button)
 
-        self.full_report_btn = Gtk.Button.new_with_label(_("Full Report"))
+        self.full_report_btn = Gtk.Button.new_with_label(_("Full report"))
         self.full_report_btn.connect("clicked",self.on_full_report_button)
 
         hbox.pack_start(self.normal_report_btn, True, True, 4)
         hbox.pack_start(self.full_report_btn, True, True, 4)
         
-
         vbox.pack_start(hbox, True, True, 4)
 
         self.progress_bar = Gtk.ProgressBar()
@@ -590,7 +595,7 @@ class ReportDialog(Gtk.Window):
             self.progress_bar.pulse()
         
         if args[1] != "":
-            self.progress_bar.set_text("Report dumped at " + args[1])
+            self.progress_bar.set_text("Completed! Report dumped at " + args[1])
 
     def on_report_button(self, widget):
         self.bar_thread = ReportThread(self.prog_bar_proc, "report")

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -601,8 +601,10 @@ class ReportDialog(Gtk.Window):
         vboxmv.set_margin_bottom(10)
 
         hboxmv = Gtk.HBox()
-        hboxmv.set_margin_start(5)
-        hboxmv.set_margin_end(5)
+        hboxmv.set_margin_start(10)
+        hboxmv.set_margin_end(10)
+        hboxmv.set_margin_top(15)
+        hboxmv.set_margin_bottom(15)
 
         self.path_label = Gtk.Label.new(self.path)
         vboxmv.pack_start(self.path_label, True, True, 4)
@@ -626,8 +628,10 @@ class ReportDialog(Gtk.Window):
         vboxev.set_margin_bottom(10)
 
         hboxev = Gtk.HBox()
-        hboxev.set_margin_start(5)
-        hboxev.set_margin_end(5)
+        hboxev.set_margin_start(10)
+        hboxev.set_margin_end(10)
+        hboxev.set_margin_top(15)
+        hboxev.set_margin_bottom(15)
 
         self.err_code = ""
 
@@ -655,6 +659,7 @@ class ReportDialog(Gtk.Window):
     def prog_bar_proc(self, args):
         if args[0] == True:
             self.path_label.set_label("Succesful! Dumped at " + self.path)
+            self.resize(200, 100)
             self.stack.set_visible_child_name("Message view")
             self.progress_bar.set_fraction(1.0)
         else:
@@ -663,6 +668,7 @@ class ReportDialog(Gtk.Window):
         if args[1] != "":
             self.err_code_label.set_label("Error! Report wasn't able to be generated\nError : " + self.err_code)
             self.stack.set_visible_child_name("Error view")
+            self.resize(200, 100)
             self.err_code = args[1]
 
         if args[2] != "":

--- a/slimbook/usr/share/slimbook/common.py
+++ b/slimbook/usr/share/slimbook/common.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import time
 import slimbook.info
 import slimbook.smbios
 
@@ -28,7 +27,6 @@ import locale
 import gettext
 import requests
 import re
-
 import signal
 
 try:

--- a/slimbook/usr/share/slimbook/common.py
+++ b/slimbook/usr/share/slimbook/common.py
@@ -517,5 +517,3 @@ def report_proc(self, glib_cb, cb, report_type):
         cb_args.insert(0, True)
 
         glib_cb(cb, cb_args)  
-
-        subprocess.Popen(["xdg-open", (cb_args[1])[:-7]])

--- a/slimbook/usr/share/slimbook/common.py
+++ b/slimbook/usr/share/slimbook/common.py
@@ -492,8 +492,8 @@ def download_feed():
     f.write(r.content)
     f.close()
 
-def report_proc(self, glib_cb, cb):
-        proc = subprocess.Popen(["slimbookctl", "report"], stdout= subprocess.PIPE, stderr= subprocess.PIPE)
+def report_proc(self, glib_cb, cb, report_type):
+        proc = subprocess.Popen(["slimbookctl", report_type], stdout= subprocess.PIPE, stderr= subprocess.PIPE)
 
         cb_args = [False, ""]
 

--- a/slimbook/usr/share/slimbook/common.py
+++ b/slimbook/usr/share/slimbook/common.py
@@ -515,3 +515,5 @@ def report_proc(self, glib_cb, cb, report_type):
         cb_args.insert(0, True)
 
         glib_cb(cb, cb_args)  
+
+        subprocess.Popen(["xdg-open", (cb_args[1])[:-7]])

--- a/slimbook/usr/share/slimbook/common.py
+++ b/slimbook/usr/share/slimbook/common.py
@@ -497,7 +497,6 @@ def download_feed():
 
 def report_proc(self, glib_cb, cb, report_type):
         proc = subprocess.Popen(["slimbookctl", report_type], stdout= subprocess.PIPE, stderr= subprocess.PIPE)
-
         cb_args = [False, "", ""]
 
         while(proc.poll() == None):
@@ -535,9 +534,9 @@ def report_proc(self, glib_cb, cb, report_type):
             proc.kill()
             o = proc.communicate()
             
-        if re.search("\/.*", o[0].decode("utf-8")):
+        if re.search(r"\/.*", o[0].decode("utf-8")):
             cb_args.pop(2)
-            path = re.search("\/.*", o[0].decode("utf-8")).group(0)
+            path = re.search(r"\/.*", o[0].decode("utf-8")).group(0)
             cb_args.append(path)
 
         cb_args.pop(0)

--- a/slimbook/usr/share/slimbook/common.py
+++ b/slimbook/usr/share/slimbook/common.py
@@ -47,6 +47,7 @@ SLB_EVENT_QC71_SUPER_LOCK_OFF = 0x05
 SLB_EVENT_QC71_SILENT_MODE = 0x06
 SLB_EVENT_QC71_NORMAL_MODE = 0x07
 SLB_EVENT_QC71_PERFORMANCE_MODE = 0x08
+SLB_EVENT_QC71_DYNAMIC_MODE = 0x09
 
 #this events are shared on several platforms and no longer are qc71 exclusive
 SLB_EVENT_TOUCHPAD_CHANGED = 0x0100
@@ -72,7 +73,8 @@ SLB_EVENT_DATA = {
     SLB_EVENT_QC71_SILENT_MODE : [_("Silent Mode"),"power-profile-power-saver-symbolic"],
     SLB_EVENT_QC71_NORMAL_MODE : [_("Normal Mode"),"power-profile-balanced-symbolic"],
     SLB_EVENT_QC71_PERFORMANCE_MODE : [_("Performance Mode"),"power-profile-performance-symbolic"],
-    
+    SLB_EVENT_QC71_DYNAMIC_MODE : [_("Dynamic Mode"),"power-profile-power-saver-symbolic"],
+
     SLB_EVENT_TOUCHPAD_ON : [_("Touchpad enabled"),"input-touchpad-symbolic"],
     SLB_EVENT_TOUCHPAD_OFF : [_("Touchpad disabled"),"input-touchpad-symbolic"],
     SLB_EVENT_TOUCHPAD_CHANGED : [_("Touchpad changed"),"input-touchpad-symbolic"],

--- a/slimbook/usr/share/slimbook/common.py
+++ b/slimbook/usr/share/slimbook/common.py
@@ -497,10 +497,32 @@ def download_feed():
 def report_proc(self, glib_cb, cb, report_type):
         proc = subprocess.Popen(["slimbookctl", report_type], stdout= subprocess.PIPE, stderr= subprocess.PIPE)
 
-        cb_args = [False, ""]
+        cb_args = [False, "", ""]
 
-        while(proc.poll() != 0 and proc.poll() == None):
+        while(proc.poll() == None):
             glib_cb(cb, cb_args)  
+
+        if(proc.poll() != 0):
+            ret_code = proc.poll()
+
+            match ret_code:
+                #should never happen
+                case 1:
+                    cb_args[2] = "error"
+                case 129:
+                    cb_args[2] = "terminal disconnected (SIGHUP)"
+                #should never happen
+                case 130:
+                    cb_args[2] = "process stopping by user(SIGINT)"
+                case 137:
+                    cb_args[2] = "process killed (SIGKILL)"
+                case 143:
+                    cb_args[2] = "process terminated (SIGTERM)"
+                case 147:
+                    cb_args[2] = "process stopped (SIGSTOP)"
+                #should never happen
+                case 148:
+                    cb_args[2] = "process stopped by user (SIGSTP)"
 
         try:
             o = proc.communicate(timeout = 5) 


### PR DESCRIPTION
Adds an option for generating a report and full report using `slimbookctl`in the context menu of `slimbookindicator`.

Implemented the `report_proc` in `common.py` since it looked more clean having it there than having it in `client.py`.

If the code needs comments, I can add them, however IMO looks auto-explicative already.